### PR TITLE
Gluon farm by pulling pion apart using minecarts

### DIFF
--- a/elementary_craft.mcreator
+++ b/elementary_craft.mcreator
@@ -1532,6 +1532,35 @@
       "locked_code": false,
       "ids": {},
       "registry_name": "pion_nul_from_down_craft_green"
+    },
+    {
+      "name": "PionMinecart",
+      "type": "procedure",
+      "sortid": 85,
+      "compiles": true,
+      "locked_code": true,
+      "ids": {},
+      "registry_name": "pion_minecart",
+      "metadata": {
+        "dependencies": [
+          {
+            "name": "x",
+            "type": "number"
+          },
+          {
+            "name": "y",
+            "type": "number"
+          },
+          {
+            "name": "z",
+            "type": "number"
+          },
+          {
+            "name": "world",
+            "type": "world"
+          }
+        ]
+      }
     }
   ],
   "variable_elements": [],
@@ -1539,10 +1568,10 @@
   "language_map": {
     "en_us": {
       "item.elementary_craft.gluon": "Gluon",
-      "block.elementary_craft.photon_field": "Photon Field",
       "block.elementary_craft.neutrino": "Neutrino",
-      "item.elementary_craft.down_quark_blue": "Downquark (Blue)",
+      "block.elementary_craft.photon_field": "Photon Field",
       "item.elementary_craft.anti_down_quark_green": "Anti Downquark (Green)",
+      "item.elementary_craft.down_quark_blue": "Downquark (Blue)",
       "block.elementary_craft.electronquantumfieldblock": "Electronquantumfieldblock",
       "block.elementary_craft.neutron": "Neutron",
       "item.elementary_craft.photon": "Photon",

--- a/elements/PionMinecart.mod.json
+++ b/elements/PionMinecart.mod.json
@@ -1,0 +1,7 @@
+{
+  "_fv": 10,
+  "_type": "procedure",
+  "definition": {
+    "procedurexml": "<xml xmlns=\"https://developers.google.com/blockly/xml\"><block type=\"event_trigger\" deletable=\"false\" x=\"-123\" y=\"-147\"><field name=\"trigger\">no_ext_trigger</field><next><block type=\"entity_nbt_logic_set\"><value name=\"entity\"><block type=\"world_entity_inrange\"><field name=\"entity\">EntityMinecart</field><value name=\"x\"><block type=\"coord_x\"/></value><value name=\"y\"><block type=\"coord_y\"/></value><value name=\"z\"><block type=\"coord_z\"/></value><value name=\"range\"><block type=\"math_number\"><field name=\"NUM\">4</field></block></value></block></value><value name=\"tagName\"><block type=\"text\"><field name=\"TEXT\">tagName</field></block></value><value name=\"tagValue\"><block type=\"logic_boolean\"><field name=\"BOOL\">TRUE</field></block></value></block></next></block></xml>"
+  }
+}

--- a/elements/PionMinus.mod.json
+++ b/elements/PionMinus.mod.json
@@ -13,9 +13,9 @@
     "rotationMode": 0,
     "emissiveRendering": false,
     "itemTexture": "pionminus",
-    "hasTransparency": true,
+    "hasTransparency": false,
     "connectedSides": false,
-    "transparencyType": "TRANSLUCENT",
+    "transparencyType": "CUTOUT",
     "mx": 0.0,
     "my": 0.0,
     "mz": 0.0,
@@ -57,7 +57,7 @@
     "isLadder": false,
     "slipperiness": 0.6,
     "reactionToPushing": "NORMAL",
-    "isNotColidable": true,
+    "isNotColidable": false,
     "soundOnStep": {
       "value": "CLOTH"
     },
@@ -90,6 +90,9 @@
     "fluidRestrictions": [],
     "onTickUpdate": {
       "name": "ChargedPionDecay"
+    },
+    "onRedstoneOn": {
+      "name": "PionMinecart"
     },
     "spawnWorldTypes": [],
     "restrictionBiomes": [],

--- a/elements/PionNulFromDown.mod.json
+++ b/elements/PionNulFromDown.mod.json
@@ -13,9 +13,9 @@
     "rotationMode": 0,
     "emissiveRendering": false,
     "itemTexture": "pionnulfromup",
-    "hasTransparency": true,
+    "hasTransparency": false,
     "connectedSides": false,
-    "transparencyType": "TRANSLUCENT",
+    "transparencyType": "CUTOUT",
     "mx": 0.0,
     "my": 0.0,
     "mz": 0.0,
@@ -57,7 +57,7 @@
     "isLadder": false,
     "slipperiness": 0.6,
     "reactionToPushing": "NORMAL",
-    "isNotColidable": true,
+    "isNotColidable": false,
     "soundOnStep": {
       "value": "CLOTH"
     },
@@ -90,6 +90,9 @@
     "fluidRestrictions": [],
     "onTickUpdate": {
       "name": "PionNulDecay"
+    },
+    "onRedstoneOn": {
+      "name": "PionMinecart"
     },
     "spawnWorldTypes": [],
     "restrictionBiomes": [],

--- a/elements/PionNulFromUp.mod.json
+++ b/elements/PionNulFromUp.mod.json
@@ -13,9 +13,9 @@
     "rotationMode": 0,
     "emissiveRendering": false,
     "itemTexture": "pionnulfromdown",
-    "hasTransparency": true,
+    "hasTransparency": false,
     "connectedSides": false,
-    "transparencyType": "TRANSLUCENT",
+    "transparencyType": "CUTOUT",
     "mx": 0.0,
     "my": 0.0,
     "mz": 0.0,
@@ -57,7 +57,7 @@
     "isLadder": false,
     "slipperiness": 0.6,
     "reactionToPushing": "NORMAL",
-    "isNotColidable": true,
+    "isNotColidable": false,
     "soundOnStep": {
       "value": "CLOTH"
     },
@@ -90,6 +90,9 @@
     "fluidRestrictions": [],
     "onTickUpdate": {
       "name": "PionNulDecay"
+    },
+    "onRedstoneOn": {
+      "name": "PionMinecart"
     },
     "spawnWorldTypes": [],
     "restrictionBiomes": [],

--- a/elements/PionPlus.mod.json
+++ b/elements/PionPlus.mod.json
@@ -13,9 +13,9 @@
     "rotationMode": 0,
     "emissiveRendering": false,
     "itemTexture": "pionplus",
-    "hasTransparency": true,
+    "hasTransparency": false,
     "connectedSides": false,
-    "transparencyType": "TRANSLUCENT",
+    "transparencyType": "CUTOUT",
     "mx": 0.0,
     "my": 0.0,
     "mz": 0.0,
@@ -57,7 +57,7 @@
     "isLadder": false,
     "slipperiness": 0.6,
     "reactionToPushing": "NORMAL",
-    "isNotColidable": true,
+    "isNotColidable": false,
     "soundOnStep": {
       "value": "CLOTH"
     },
@@ -90,6 +90,9 @@
     "fluidRestrictions": [],
     "onTickUpdate": {
       "name": "ChargedPionDecay"
+    },
+    "onRedstoneOn": {
+      "name": "PionMinecart"
     },
     "spawnWorldTypes": [],
     "restrictionBiomes": [],

--- a/src/main/java/net/mcreator/elementarycraft/block/PionMinusBlock.java
+++ b/src/main/java/net/mcreator/elementarycraft/block/PionMinusBlock.java
@@ -46,6 +46,7 @@ import net.minecraft.block.SoundType;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Block;
 
+import net.mcreator.elementarycraft.procedures.PionMinecartProcedure;
 import net.mcreator.elementarycraft.procedures.ChargedPionDecayProcedure;
 import net.mcreator.elementarycraft.itemgroup.ElementaryParticleItemGroup;
 import net.mcreator.elementarycraft.ElementaryCraftModElements;
@@ -85,18 +86,12 @@ public class PionMinusBlock extends ElementaryCraftModElements.ModElement {
 	@Override
 	@OnlyIn(Dist.CLIENT)
 	public void clientLoad(FMLClientSetupEvent event) {
-		RenderTypeLookup.setRenderLayer(block, RenderType.getTranslucent());
+		RenderTypeLookup.setRenderLayer(block, RenderType.getCutout());
 	}
 	public static class CustomBlock extends Block {
 		public CustomBlock() {
-			super(Block.Properties.create(Material.ROCK).sound(SoundType.CLOTH).hardnessAndResistance(1f, 10f).lightValue(0).doesNotBlockMovement()
-					.notSolid());
+			super(Block.Properties.create(Material.ROCK).sound(SoundType.CLOTH).hardnessAndResistance(1f, 10f).lightValue(0));
 			setRegistryName("pion_minus");
-		}
-
-		@Override
-		public boolean isNormalCube(BlockState state, IBlockReader worldIn, BlockPos pos) {
-			return false;
 		}
 
 		@Override
@@ -114,6 +109,25 @@ public class PionMinusBlock extends ElementaryCraftModElements.ModElement {
 			int y = pos.getY();
 			int z = pos.getZ();
 			world.getPendingBlockTicks().scheduleTick(new BlockPos(x, y, z), this, this.tickRate(world));
+		}
+
+		@Override
+		public void neighborChanged(BlockState state, World world, BlockPos pos, Block neighborBlock, BlockPos fromPos, boolean moving) {
+			super.neighborChanged(state, world, pos, neighborBlock, fromPos, moving);
+			int x = pos.getX();
+			int y = pos.getY();
+			int z = pos.getZ();
+			if (world.getRedstonePowerFromNeighbors(new BlockPos(x, y, z)) > 0) {
+				{
+					Map<String, Object> $_dependencies = new HashMap<>();
+					$_dependencies.put("x", x);
+					$_dependencies.put("y", y);
+					$_dependencies.put("z", z);
+					$_dependencies.put("world", world);
+					PionMinecartProcedure.executeProcedure($_dependencies);
+				}
+			} else {
+			}
 		}
 
 		@Override

--- a/src/main/java/net/mcreator/elementarycraft/block/PionNulFromDownBlock.java
+++ b/src/main/java/net/mcreator/elementarycraft/block/PionNulFromDownBlock.java
@@ -47,6 +47,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.Block;
 
 import net.mcreator.elementarycraft.procedures.PionNulDecayProcedure;
+import net.mcreator.elementarycraft.procedures.PionMinecartProcedure;
 import net.mcreator.elementarycraft.itemgroup.ElementaryParticleItemGroup;
 import net.mcreator.elementarycraft.ElementaryCraftModElements;
 
@@ -85,18 +86,12 @@ public class PionNulFromDownBlock extends ElementaryCraftModElements.ModElement 
 	@Override
 	@OnlyIn(Dist.CLIENT)
 	public void clientLoad(FMLClientSetupEvent event) {
-		RenderTypeLookup.setRenderLayer(block, RenderType.getTranslucent());
+		RenderTypeLookup.setRenderLayer(block, RenderType.getCutout());
 	}
 	public static class CustomBlock extends Block {
 		public CustomBlock() {
-			super(Block.Properties.create(Material.ROCK).sound(SoundType.CLOTH).hardnessAndResistance(1f, 10f).lightValue(0).doesNotBlockMovement()
-					.notSolid());
+			super(Block.Properties.create(Material.ROCK).sound(SoundType.CLOTH).hardnessAndResistance(1f, 10f).lightValue(0));
 			setRegistryName("pion_nul_from_down");
-		}
-
-		@Override
-		public boolean isNormalCube(BlockState state, IBlockReader worldIn, BlockPos pos) {
-			return false;
 		}
 
 		@Override
@@ -114,6 +109,25 @@ public class PionNulFromDownBlock extends ElementaryCraftModElements.ModElement 
 			int y = pos.getY();
 			int z = pos.getZ();
 			world.getPendingBlockTicks().scheduleTick(new BlockPos(x, y, z), this, this.tickRate(world));
+		}
+
+		@Override
+		public void neighborChanged(BlockState state, World world, BlockPos pos, Block neighborBlock, BlockPos fromPos, boolean moving) {
+			super.neighborChanged(state, world, pos, neighborBlock, fromPos, moving);
+			int x = pos.getX();
+			int y = pos.getY();
+			int z = pos.getZ();
+			if (world.getRedstonePowerFromNeighbors(new BlockPos(x, y, z)) > 0) {
+				{
+					Map<String, Object> $_dependencies = new HashMap<>();
+					$_dependencies.put("x", x);
+					$_dependencies.put("y", y);
+					$_dependencies.put("z", z);
+					$_dependencies.put("world", world);
+					PionMinecartProcedure.executeProcedure($_dependencies);
+				}
+			} else {
+			}
 		}
 
 		@Override

--- a/src/main/java/net/mcreator/elementarycraft/block/PionNulFromUpBlock.java
+++ b/src/main/java/net/mcreator/elementarycraft/block/PionNulFromUpBlock.java
@@ -47,6 +47,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.Block;
 
 import net.mcreator.elementarycraft.procedures.PionNulDecayProcedure;
+import net.mcreator.elementarycraft.procedures.PionMinecartProcedure;
 import net.mcreator.elementarycraft.itemgroup.ElementaryParticleItemGroup;
 import net.mcreator.elementarycraft.ElementaryCraftModElements;
 
@@ -85,18 +86,12 @@ public class PionNulFromUpBlock extends ElementaryCraftModElements.ModElement {
 	@Override
 	@OnlyIn(Dist.CLIENT)
 	public void clientLoad(FMLClientSetupEvent event) {
-		RenderTypeLookup.setRenderLayer(block, RenderType.getTranslucent());
+		RenderTypeLookup.setRenderLayer(block, RenderType.getCutout());
 	}
 	public static class CustomBlock extends Block {
 		public CustomBlock() {
-			super(Block.Properties.create(Material.ROCK).sound(SoundType.CLOTH).hardnessAndResistance(1f, 10f).lightValue(0).doesNotBlockMovement()
-					.notSolid());
+			super(Block.Properties.create(Material.ROCK).sound(SoundType.CLOTH).hardnessAndResistance(1f, 10f).lightValue(0));
 			setRegistryName("pion_nul_from_up");
-		}
-
-		@Override
-		public boolean isNormalCube(BlockState state, IBlockReader worldIn, BlockPos pos) {
-			return false;
 		}
 
 		@Override
@@ -114,6 +109,25 @@ public class PionNulFromUpBlock extends ElementaryCraftModElements.ModElement {
 			int y = pos.getY();
 			int z = pos.getZ();
 			world.getPendingBlockTicks().scheduleTick(new BlockPos(x, y, z), this, this.tickRate(world));
+		}
+
+		@Override
+		public void neighborChanged(BlockState state, World world, BlockPos pos, Block neighborBlock, BlockPos fromPos, boolean moving) {
+			super.neighborChanged(state, world, pos, neighborBlock, fromPos, moving);
+			int x = pos.getX();
+			int y = pos.getY();
+			int z = pos.getZ();
+			if (world.getRedstonePowerFromNeighbors(new BlockPos(x, y, z)) > 0) {
+				{
+					Map<String, Object> $_dependencies = new HashMap<>();
+					$_dependencies.put("x", x);
+					$_dependencies.put("y", y);
+					$_dependencies.put("z", z);
+					$_dependencies.put("world", world);
+					PionMinecartProcedure.executeProcedure($_dependencies);
+				}
+			} else {
+			}
 		}
 
 		@Override

--- a/src/main/java/net/mcreator/elementarycraft/block/PionPlusBlock.java
+++ b/src/main/java/net/mcreator/elementarycraft/block/PionPlusBlock.java
@@ -46,6 +46,7 @@ import net.minecraft.block.SoundType;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Block;
 
+import net.mcreator.elementarycraft.procedures.PionMinecartProcedure;
 import net.mcreator.elementarycraft.procedures.ChargedPionDecayProcedure;
 import net.mcreator.elementarycraft.itemgroup.ElementaryParticleItemGroup;
 import net.mcreator.elementarycraft.ElementaryCraftModElements;
@@ -85,18 +86,12 @@ public class PionPlusBlock extends ElementaryCraftModElements.ModElement {
 	@Override
 	@OnlyIn(Dist.CLIENT)
 	public void clientLoad(FMLClientSetupEvent event) {
-		RenderTypeLookup.setRenderLayer(block, RenderType.getTranslucent());
+		RenderTypeLookup.setRenderLayer(block, RenderType.getCutout());
 	}
 	public static class CustomBlock extends Block {
 		public CustomBlock() {
-			super(Block.Properties.create(Material.ROCK).sound(SoundType.CLOTH).hardnessAndResistance(1f, 10f).lightValue(0).doesNotBlockMovement()
-					.notSolid());
+			super(Block.Properties.create(Material.ROCK).sound(SoundType.CLOTH).hardnessAndResistance(1f, 10f).lightValue(0));
 			setRegistryName("pion_plus");
-		}
-
-		@Override
-		public boolean isNormalCube(BlockState state, IBlockReader worldIn, BlockPos pos) {
-			return false;
 		}
 
 		@Override
@@ -114,6 +109,25 @@ public class PionPlusBlock extends ElementaryCraftModElements.ModElement {
 			int y = pos.getY();
 			int z = pos.getZ();
 			world.getPendingBlockTicks().scheduleTick(new BlockPos(x, y, z), this, this.tickRate(world));
+		}
+
+		@Override
+		public void neighborChanged(BlockState state, World world, BlockPos pos, Block neighborBlock, BlockPos fromPos, boolean moving) {
+			super.neighborChanged(state, world, pos, neighborBlock, fromPos, moving);
+			int x = pos.getX();
+			int y = pos.getY();
+			int z = pos.getZ();
+			if (world.getRedstonePowerFromNeighbors(new BlockPos(x, y, z)) > 0) {
+				{
+					Map<String, Object> $_dependencies = new HashMap<>();
+					$_dependencies.put("x", x);
+					$_dependencies.put("y", y);
+					$_dependencies.put("z", z);
+					$_dependencies.put("world", world);
+					PionMinecartProcedure.executeProcedure($_dependencies);
+				}
+			} else {
+			}
 		}
 
 		@Override

--- a/src/main/java/net/mcreator/elementarycraft/procedures/PionMinecartProcedure.java
+++ b/src/main/java/net/mcreator/elementarycraft/procedures/PionMinecartProcedure.java
@@ -1,0 +1,103 @@
+package net.mcreator.elementarycraft.procedures;
+
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.common.MinecraftForge;
+
+import net.minecraft.entity.item.minecart.MinecartEntity;
+import net.minecraft.entity.item.ItemEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.IWorld;
+import net.minecraft.util.math.AxisAlignedBB;
+
+import net.mcreator.elementarycraft.item.GluonItem;
+import net.mcreator.elementarycraft.ElementaryCraftMod;
+import net.mcreator.elementarycraft.ElementaryCraftModElements;
+
+import java.lang.Math;
+import java.util.List;
+import java.util.Set;
+import java.util.Map;
+import java.util.Comparator;
+import java.util.HashSet;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import net.minecraft.client.Minecraft;
+
+@ElementaryCraftModElements.ModElement.Tag
+public class PionMinecartProcedure extends ElementaryCraftModElements.ModElement {
+	private static final Set<MinecartEntity> pionMinecarts = new HashSet<>();
+	private static final Logger logger = LogManager.getLogger("ElementaryCraftMod");
+	private static final int TICKS = 5;
+
+	private final Set<MinecartEntity> tempMinecarts = new HashSet<>();
+	private int ticks = 0;
+
+	public PionMinecartProcedure(ElementaryCraftModElements instance) {
+		super(instance, 85);
+		MinecraftForge.EVENT_BUS.register(this);
+	}
+
+	public static void executeProcedure(Map<String, Object> dependencies) {
+		if (dependencies.get("x") == null) {
+			System.err.println("Failed to load dependency x for procedure PionMinecart!");
+			return;
+		}
+		if (dependencies.get("y") == null) {
+			System.err.println("Failed to load dependency y for procedure PionMinecart!");
+			return;
+		}
+		if (dependencies.get("z") == null) {
+			System.err.println("Failed to load dependency z for procedure PionMinecart!");
+			return;
+		}
+		if (dependencies.get("world") == null) {
+			System.err.println("Failed to load dependency world for procedure PionMinecart!");
+			return;
+		}
+		double x = dependencies.get("x") instanceof Integer ? (int) dependencies.get("x") : (double) dependencies.get("x");
+		double y = dependencies.get("y") instanceof Integer ? (int) dependencies.get("y") : (double) dependencies.get("y");
+		double z = dependencies.get("z") instanceof Integer ? (int) dependencies.get("z") : (double) dependencies.get("z");
+		IWorld world = (IWorld) dependencies.get("world");
+
+		List<MinecartEntity> minecarts = world.getEntitiesWithinAABB(MinecartEntity.class, new AxisAlignedBB(x - 1, y, z, x + 2, y + 1, z + 1), null);
+		if (minecarts.isEmpty()) {
+			minecarts = world.getEntitiesWithinAABB(MinecartEntity.class, new AxisAlignedBB(x, y, z - 1, x + 1, y + 1, z + 2), null);
+		}
+		if (minecarts.isEmpty()) {
+			return;
+		}
+
+		pionMinecarts.addAll(minecarts);
+	}
+
+	@SubscribeEvent
+	public void onServerTick(TickEvent.ServerTickEvent event) {
+		if (event.phase == TickEvent.Phase.END && !pionMinecarts.isEmpty()) {
+			if (ticks > 0) {
+				tempMinecarts.clear();
+				System.err.println("Skipping 1 tick (" + ticks + ")");
+			} else {
+				pionMinecarts.forEach(minecart -> {
+					if ((Math.abs(minecart.getMotion().x) < 0.00001 && Math.abs(minecart.getMotion().y) < 0.00001 && Math.abs(minecart.getMotion().z) < 0.00001) || tempMinecarts.contains(minecart)) {
+						return;
+					}
+					ItemEntity entityToSpawn = new ItemEntity(
+						minecart.world.getWorld(),
+						minecart.getPosition().getX(),
+						minecart.getPosition().getY(),
+						minecart.getPosition().getZ(),
+						new ItemStack(GluonItem.block, (int) (1))
+					);
+					entityToSpawn.setPickupDelay(10);
+					minecart.world.addEntity(entityToSpawn);
+					tempMinecarts.add(minecart);
+					System.err.println("Spawning gluon (" + ticks + ") for minecart " + minecart);
+				});
+				pionMinecarts.removeIf(minecart -> Math.abs(minecart.getMotion().x) < 0.00001 && Math.abs(minecart.getMotion().y) < 0.00001 && Math.abs(minecart.getMotion().z) < 0.00001);
+			}
+			ticks = (ticks + 1) % TICKS;
+		}
+	}
+}


### PR DESCRIPTION
First implementation of the gluon farm.

Setup:

Place down two powered rails with a one block gap in between, extend the track with normal rails to either side. Next, place two minecarts, one on each of the powered rails. Finally place a pion block in between the minecarts, place a button on the pion block and press the button.

Two remarks:

1. I've had to set the pion to be non-transparent, due to the way the farm works. Hopefully we can find a way around this with the textures.
2. Currently the pion does not really get destroyed, I'm just relying on the decay feature. This can be changed, I'm just not 100% sure what had to happen.

Lastly I've also had to resort to custom coding this procedure, since mcreator was too limiting. The main thing that might want to be changed is the "TICKS" variable (near the top of the class), it determines how often gluons will spawn when the minecarts are moving. The lower the value, the more often they will spawn.